### PR TITLE
Melhorias nos Eventos

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,35 @@
 //= require bootstrap-datetimepicker
 //= require pickers
 //= require pt-br
+//= require_self
 //= require_tree .
+
+//////////////// Thanks Jonatan Klosko! ///////////////////
+// https://gist.github.com/jonatanklosko/a4c2df8a0eae64289eec
+// Executes the given function on the specified page/pages.
+// Requires body to have class '<controller> <action>'.
+// The given pageSelector should have a format: '<controller> <action>'.
+// Could be followed by comma and another pageSelector.
+// Example: 'users show, users edit, users update, sessions new'.
+// ----------------------------------------------------------------------
+// For turbolinks 5, you have to replace page:change with turbolinks:load
+function onPage(pageSelector, fun) {
+  pageSelector = pageSelector.replace(/, /g, ',.')
+                             .replace(/ /g, '.')
+                             .replace(/^/, '.');
+  $(document).on('turbolinks:load', function() {
+    if ($(pageSelector).length > 0) {
+      fun();
+    }
+  });
+}
+
+// Executes the given function on every page.
+function onEveryPage(fun) {
+  $(document).on('turbolinks:load', fun);
+}
+
+moment.locale('pt-BR');
 
 $(function() {
   $datetimepicker = $('.date_picker.form-control, .datetime_picker.form-control');

--- a/app/assets/javascripts/eventos.js
+++ b/app/assets/javascripts/eventos.js
@@ -1,0 +1,17 @@
+onPage('eventos edit', function() {
+  function esconder() {
+    if($("#evento_site_externo").is(":checked")) {
+      $(".evento_site").show();
+      $(".esconder").hide();
+    } else {
+      $(".evento_site").hide();
+      $(".esconder").show();
+    }
+  }
+
+  esconder();
+
+  $("#evento_site_externo").on("change", function(){
+    esconder();
+  })
+});

--- a/app/models/evento.rb
+++ b/app/models/evento.rb
@@ -1,3 +1,8 @@
 class Evento < ActiveRecord::Base
   validates :nome, :data_inicio, :data_fim, :local, :endereco, presence: true
+
+  before_validation :gerar_codigo
+  private def gerar_codigo
+    self.codigo = nome.parameterize
+  end
 end

--- a/app/views/eventos/_eventos.html.erb
+++ b/app/views/eventos/_eventos.html.erb
@@ -2,10 +2,10 @@
   <div class="evento">
     <h3 class="titulo"><%= evento.nome %></h3>
     <p class="data">
-      Data: <%=l evento.data_inicio, format: :post %>.
+      Data: <%=l evento.data_inicio, format: :default %>
     </p>
     <p class="local">
-      Local: <%= evento.local%>.
+      Local: <%= evento.local%>
     </p>
     <p class="mais">
       <%= link_to reverse_icon('Detalhes', 'arrow-right'), evento_path(evento), class: 'btn btn-primary' %>

--- a/app/views/eventos/_form.html.erb
+++ b/app/views/eventos/_form.html.erb
@@ -1,16 +1,19 @@
 <%= simple_form_for @evento do |f| %>
   <%= f.input :nome, required: true %>
-  <%= f.input :data_inicio, required: true, label: "Data de início", as: :date, html5: true %>
-  <%= f.input :data_fim, required: true, label: "Data de término", as: :date, html5: true %>
+  <%= f.input :data_inicio, required: true, label: "Data de início", as: :date_picker, html5: true %>
+  <%= f.input :data_fim, required: true, label: "Data de término", as: :date_picker, html5: true %>
   <%= f.input :local, required: true %>
   <%= f.input :endereco, required: true, label: "Endereço" %>
+  <%= f.input :site_externo, label: "Usar site externo?" %>
   <%= f.input :site %>
-  <%= f.input :intro, label: "Introdução" %>
-  <%= f.input :modalidades %>
-  <%= f.input :cronograma %>
-  <%= f.input :inscricoes, label: "Inscrições" %>
+  <div class="esconder">
+    <%= f.input :intro, label: "Introdução" %>
+    <%= f.input :modalidades %>
+    <%= f.input :cronograma %>
+    <%= f.input :inscricoes, label: "Inscrições" %>
+  </div>
   <%= f.input :resultados %>
   <%= f.button :submit, "Salvar", class: "btn btn-success" %>
 
-  <%= link_to icon('remove', 'Cancelar'), root_url, class: "btn btn-warning" %>
+  <%= link_to icon('remove', 'Cancelar'), eventos_path, class: "btn btn-warning" %>
 <% end %>

--- a/app/views/eventos/edit.html.erb
+++ b/app/views/eventos/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <h3>Editar evento</h3>
   <div class="eventos-form">
-    <%= render '_form'%>
+    <%= render 'form'%>
   </div>
 </div>

--- a/app/views/eventos/new.html.erb
+++ b/app/views/eventos/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <h3>Cadastrar novo evento</h3>
   <div class="eventos-form">
-    <%= render '_form'%>
+    <%= render 'form'%>
   </div>
 </div>

--- a/app/views/eventos/show.html.erb
+++ b/app/views/eventos/show.html.erb
@@ -1,34 +1,37 @@
 <div class="container">
   <h3><%= @evento.nome %></h3>
   <p class="data">
-      Data de início: <%=l @evento.data_inicio, format: :post %>.
+    Data de início: <%=l @evento.data_inicio, format: :long %>
   </p>
   <p class="data">
-      Data de término: <%=l @evento.data_inicio, format: :post %>.
+    Data de término: <%=l @evento.data_inicio, format: :long %>
   </p>
   <p class="local">
-    Local: <%= @evento.local%>.
+    Local: <%= @evento.local%>
   </p>
   <p class="endereco">
-    Endereço: <%= @evento.endereco%>.
+    Endereço: <%= @evento.endereco%>
   </p>
-  <p class="site">
-    Site: <%= @evento.site%>.
-  </p>
-  <p class="intro">
-    Introdução: <%= @evento.intro%>.
-  </p>
-  <p class="modalidades">
-    Modalidades: <%= @evento.modalidades%>.
-  </p>
-  <p class="cronograma">
-    Cronograma: <%= @evento.cronograma%>.
-  </p>
-  <p class="inscricoes">
-    Inscriçoes: <%= @evento.inscricoes%>.
-  </p>
+  <% if @evento.site_externo %>
+    <p class="site">
+      Site: <%= @evento.site%>
+    </p>
+  <% else %>
+    <p class="intro">
+      Introdução: <%= @evento.intro%>
+    </p>
+    <p class="modalidades">
+      Modalidades: <%= @evento.modalidades%>
+    </p>
+    <p class="cronograma">
+      Cronograma: <%= @evento.cronograma%>
+    </p>
+    <p class="inscricoes">
+      Inscriçoes: <%= @evento.inscricoes%>
+    </p>
+  <% end %>
   <p class="resultados">
-    Resultados: <%= @evento.resultados%>.
+    Resultados: <%= @evento.resultados%>
   </p>
   <% if current_user && current_user.pode_postar_evento? %>
     <%= link_to glyphicon('pencil') + " Editar", edit_evento_path(@evento), class: "btn btn-info" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>
-<body>
+<body class="<%= controller_name %> <%= action_name %>">
 
 <div class="container">
   <%= render 'layouts/flash' %>

--- a/db/migrate/20170204134755_novos_campos_em_eventos.rb
+++ b/db/migrate/20170204134755_novos_campos_em_eventos.rb
@@ -1,0 +1,11 @@
+class NovosCamposEmEventos < ActiveRecord::Migration
+  def up
+    add_column :eventos, :codigo, :string
+    add_column :eventos, :site_externo, :boolean
+  end
+
+  def down
+    remove_column :eventos, :codigo
+    remove_column :eventos, :site_externo
+  end
+end

--- a/db/migrate/20170204134755_novos_campos_em_eventos.rb
+++ b/db/migrate/20170204134755_novos_campos_em_eventos.rb
@@ -2,6 +2,8 @@ class NovosCamposEmEventos < ActiveRecord::Migration
   def up
     add_column :eventos, :codigo, :string
     add_column :eventos, :site_externo, :boolean
+    change_column :eventos, :data_inicio, :date
+    change_column :eventos, :data_fim, :date
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170127014559) do
+ActiveRecord::Schema.define(version: 20170204134755) do
 
   create_table "associados", force: :cascade do |t|
     t.integer  "user_id",         limit: 4


### PR DESCRIPTION
Novos campos: codigo* e site_externo.

O codigo é gerado automaticamente, igual o slug da notícias, mas talvez podemos deixar o campo pro usuário preencher.

O site_externo é usado para definir se o evento tem um site próprio. Caso tenha, os campos introdução, inscrições, cronograma, etc não são mostrados (na edição nem na visão pública).