### PR TITLE
Altera exibição de campos para site externo na página de criação de eventos

### DIFF
--- a/app/assets/javascripts/eventos.js
+++ b/app/assets/javascripts/eventos.js
@@ -1,4 +1,4 @@
-onPage('eventos edit', function() {
+onPage('eventos edit, eventos new', function() {
   function esconder() {
     if($("#evento_site_externo").is(":checked")) {
       $(".evento_site").show();


### PR DESCRIPTION
Pequena correção para que os campos de site externo sejam exibidos/ocultados conforme comportamento do botão, na página de novo evento, da mesma forma que ocorre em editar evento.